### PR TITLE
Translate UI labels to Korean

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -14,10 +14,10 @@ namespace UniverseBounty
 
         private static readonly NamedAction[] Tabs =
         {
-            new NamedAction("ECONOMY", EconomyUI.OnGUI),
-            new NamedAction("RESEARCH", ResearchUI.OnGUI),
-            new NamedAction("FACTIONS", FactionsUI.OnGUI),
-            new NamedAction("COUNCILORS", CouncilorsUI.OnGUI)
+            new NamedAction("경제", EconomyUI.OnGUI),
+            new NamedAction("연구", ResearchUI.OnGUI),
+            new NamedAction("세력", FactionsUI.OnGUI),
+            new NamedAction("평의원", CouncilorsUI.OnGUI)
         };
 
         public static bool Load(UnityModManager.ModEntry entry)

--- a/src/CouncilorsUI.cs
+++ b/src/CouncilorsUI.cs
@@ -37,25 +37,25 @@ namespace UniverseBounty
         {
             using (UI.HorizontalScope())
             {
-                UI.Label("NAME".bold(), UI.MinWidth(249), UI.MaxWidth(249));
+                UI.Label("이름".bold(), UI.MinWidth(249), UI.MaxWidth(249));
                 UI.Space(10);
-                DrawAttributeHeader("AGE");
+                DrawAttributeHeader("나이");
                 UI.Space(10);
-                DrawAttributeHeader("PER");
+                DrawAttributeHeader("설득");
                 UI.Space(10);
-                DrawAttributeHeader("INV");
+                DrawAttributeHeader("조사");
                 UI.Space(10);
-                DrawAttributeHeader("ESP");
+                DrawAttributeHeader("첩보");
                 UI.Space(10);
-                DrawAttributeHeader("COM");
+                DrawAttributeHeader("지휘");
                 UI.Space(10);
-                DrawAttributeHeader("ADM");
+                DrawAttributeHeader("관리");
                 UI.Space(10);
-                DrawAttributeHeader("SCI");
+                DrawAttributeHeader("과학");
                 UI.Space(10);
-                DrawAttributeHeader("SEC");
+                DrawAttributeHeader("안보");
                 UI.Space(10);
-                DrawAttributeHeader("LOY");
+                DrawAttributeHeader("충성");
                 UI.Space(10);
             }
         }
@@ -92,7 +92,7 @@ namespace UniverseBounty
                     DrawCouncilorAttribute(councilor, CouncilorAttribute.Loyalty);
                     UI.Space(20);
                     UI.ActionButton(
-                        "+20 XP",
+                        "+20 경험치",
                         () =>
                         {
                             councilor.ChangeXP(20);
@@ -105,7 +105,7 @@ namespace UniverseBounty
 
                     var traitsGlyph = IsSelectedCouncilor(councilor) ? UI.DisclosureGlyphOn : UI.DisclosureGlyphOff;
                     UI.ActionButton(
-                        $"Traits {traitsGlyph}",
+                        $"특성 {traitsGlyph}",
                         () => { ToggleCouncilor(councilor); },
                         UI.MinWidth(100),
                         UI.MaxWidth(100)

--- a/src/EconomyUI.cs
+++ b/src/EconomyUI.cs
@@ -11,7 +11,7 @@ namespace UniverseBounty
     public static class EconomyUI
     {
         private static TIFactionState? Faction;
-        private const string ShipBuildTimeTemplate = "It currently takes <b>{0}/{1}/{2}</b> days to build a dreadnought via space dock/shipyard/spaceworks.";
+        private const string ShipBuildTimeTemplate = "현재 드레드노트를 우주 도크/조선소/우주공장에서 건조하는 데 각각 <b>{0}/{1}/{2}</b> 일이 소요됩니다.";
         private const string ShipConstructionEffectName = "Effect_ShipConstructionTimeReduction10";
         private const string ControlPointBonusEffectName = "Effect_ControlPointMaintenanceBonus10";
 
@@ -21,10 +21,10 @@ namespace UniverseBounty
 
             using (UI.VerticalScope())
             {
-                UIElements.Header("RESOURCES");
+                UIElements.Header("자원");
                 DrawResources();
 
-                UIElements.Header("CONSTRUCTION");
+                UIElements.Header("건설");
                 DrawConstruction();
             }
         }
@@ -37,7 +37,7 @@ namespace UniverseBounty
         private static void DrawResources()
         {
             DrawResourceButtons(
-                "Money",
+                "자금",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Money, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Money, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Money, 10000)),
@@ -47,7 +47,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Influence",
+                "영향력",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Influence, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Influence, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Influence, 10000)),
@@ -57,7 +57,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Operations",
+                "작전",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Operations, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Operations, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Operations, 10000)),
@@ -67,7 +67,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Boost",
+                "부스트",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Boost, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Boost, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Boost, 10000)),
@@ -77,7 +77,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Water",
+                "물",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Water, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Water, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Water, 10000)),
@@ -87,7 +87,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Metals",
+                "금속",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Metals, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Metals, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Metals, 10000)),
@@ -97,7 +97,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Noble Metals",
+                "귀금속",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.NobleMetals, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.NobleMetals, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.NobleMetals, 10000)),
@@ -107,7 +107,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Fissiles",
+                "핵물질",
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Fissiles, 100)),
                 new ResourceButtonAction("+ 1,000", AddToResourceAction(FactionResource.Fissiles, 1000)),
                 new ResourceButtonAction("+ 10,000", AddToResourceAction(FactionResource.Fissiles, 10000)),
@@ -117,7 +117,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Antimatter",
+                "반물질",
                 new ResourceButtonAction("+ 1", AddToResourceAction(FactionResource.Antimatter, 1)),
                 new ResourceButtonAction("+ 5", AddToResourceAction(FactionResource.Antimatter, 5)),
                 new ResourceButtonAction("+ 10", AddToResourceAction(FactionResource.Antimatter, 10)),
@@ -127,7 +127,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Exotics",
+                "특수 자원",
                 new ResourceButtonAction("+ 10", AddToResourceAction(FactionResource.Exotics, 1)),
                 new ResourceButtonAction("+ 50", AddToResourceAction(FactionResource.Exotics, 50)),
                 new ResourceButtonAction("+ 100", AddToResourceAction(FactionResource.Exotics, 100)),
@@ -137,7 +137,7 @@ namespace UniverseBounty
             UI.Space(30);
 
             DrawResourceButtons(
-                "Mission Control",
+                "임무 통제",
                 new ResourceButtonAction("+ 1", GainIncomeAction(InstantEffect.GainMissionControl, 1)),
                 new ResourceButtonAction("+ 5", GainIncomeAction(InstantEffect.GainMissionControl, 5)),
                 new ResourceButtonAction("+ 10", GainIncomeAction(InstantEffect.GainMissionControl, 10)),
@@ -146,7 +146,7 @@ namespace UniverseBounty
             UI.Space(10);
 
             DrawResourceButtons(
-                "Control Points",
+                "통제점",
                 new ResourceButtonAction("+ 10", ApplyEffectAction(ControlPointBonusEffectName))
             );
         }
@@ -166,7 +166,7 @@ namespace UniverseBounty
 
             using (UI.HorizontalScope())
             {
-                UI.Label("STARSHIPS".orange().bold(), UI.MinWidth(220), UI.MaxWidth(220));
+                UI.Label("우주선".orange().bold(), UI.MinWidth(220), UI.MaxWidth(220));
                 UI.Space(10);
                 UI.ActionButton($"- {shipBuildingAmount}", () => ApplyEffectAction(effect), UIStyles.StandardButtonStyle,
                     UI.MinWidth(150), UI.MaxWidth(150));
@@ -177,11 +177,11 @@ namespace UniverseBounty
 
             using (UI.HorizontalScope())
             {
-                UI.Label("HAB MODULES".orange().bold(), UI.MinWidth(220), UI.MaxWidth(220));
+                UI.Label("거주 모듈".orange().bold(), UI.MinWidth(220), UI.MaxWidth(220));
                 UI.Space(10);
-                UI.ActionButton("COMPLETE", OnCompleteHabModulesAction, UIStyles.StandardButtonStyle, UI.MinWidth(150), UI.MaxWidth(150));
+                UI.ActionButton("완료", OnCompleteHabModulesAction, UIStyles.StandardButtonStyle, UI.MinWidth(150), UI.MaxWidth(150));
                 UI.Space(10);
-                UI.Label("Complete all hab modules under construction", UIStyles.Hint);
+                UI.Label("건설 중인 모든 거주 모듈을 완료합니다", UIStyles.Hint);
             }
 
             return;

--- a/src/FactionsUI.cs
+++ b/src/FactionsUI.cs
@@ -52,15 +52,15 @@ namespace UniverseBounty
                 {
                     UI.Label(faction.displayName.ToUpper().orange().bold(), UI.MinWidth(300), UI.MaxWidth(300));
                     UI.Space(10);
-                    UI.ActionButton($"Projects {projectsGlyph}", () => ToggleFaction(SelectionMode.Projects, faction),
+                    UI.ActionButton($"프로젝트 {projectsGlyph}", () => ToggleFaction(SelectionMode.Projects, faction),
                         UI.MinWidth(300), UI.MaxWidth(300));
                     UI.Space(10);
-                    UI.ActionButton($"Organisations {organisationsGlyph}",
+                    UI.ActionButton($"조직 {organisationsGlyph}",
                         () => ToggleFaction(SelectionMode.Organisations, faction), UI.MinWidth(300), UI.MaxWidth(300));
                     UI.Space(10);
-                    UI.ActionButton("Reveal Intel", () => RevealIntel(faction), UI.MinWidth(300), UI.MaxWidth(300));
+                    UI.ActionButton("정보 공개", () => RevealIntel(faction), UI.MinWidth(300), UI.MaxWidth(300));
                     UI.Space(10);
-                    UI.ActionButton($"Reset Hate ({hate:N0})", () => ResetHate(faction), UI.MinWidth(300),
+                    UI.ActionButton($"혐오도 초기화 ({hate:N0})", () => ResetHate(faction), UI.MinWidth(300),
                         UI.MaxWidth(300));
                 }
 
@@ -83,7 +83,7 @@ namespace UniverseBounty
             {
                 UI.Label(faction.displayName.ToUpper().orange().bold(), UI.MinWidth(300), UI.MaxWidth(300));
                 UI.Space(10);
-                UI.ActionButton($"Reset Hate ({hate:N0})", () => ResetHate(faction), UI.MinWidth(300),
+                UI.ActionButton($"혐오도 초기화 ({hate:N0})", () => ResetHate(faction), UI.MinWidth(300),
                     UI.MaxWidth(300));
             }
         }
@@ -99,9 +99,9 @@ namespace UniverseBounty
                 UI.Space(10);
 
                 if (projects.IsEmpty())
-                    UI.Label("No projects found.", UIStyles.Hint, UI.AutoWidth());
+                    UI.Label("프로젝트가 없습니다.", UIStyles.Hint, UI.AutoWidth());
                 else
-                    UI.Label("Clicking a project will steal it and make it available for you to research.", UIStyles.Hint, UI.AutoWidth());
+                    UI.Label("프로젝트를 클릭하면 훔쳐서 연구 가능하게 됩니다.", UIStyles.Hint, UI.AutoWidth());
 
                 foreach (var chunk in projects)
                 {
@@ -136,9 +136,9 @@ namespace UniverseBounty
                 UI.Space(10);
 
                 if (organisations.IsEmpty())
-                    UI.Label("No organisations found.", UIStyles.Hint, UI.AutoWidth());
+                    UI.Label("조직이 없습니다.", UIStyles.Hint, UI.AutoWidth());
                 else
-                    UI.Label("Clicking an organisation will steal it and place it in your unassigned pool.", UIStyles.Hint, UI.AutoWidth());
+                    UI.Label("조직을 클릭하면 훔쳐서 미배정 풀에 넣습니다.", UIStyles.Hint, UI.AutoWidth());
 
                 foreach (var chunk in organisations)
                 {

--- a/src/ResearchUI.cs
+++ b/src/ResearchUI.cs
@@ -18,11 +18,11 @@ namespace UniverseBounty
             {
                 DrawUniversalResearch();
 
-                UIElements.Header("GLOBAL RESEARCH");
+                UIElements.Header("전역 연구");
 
                 DrawGlobalResearch();
 
-                UIElements.Header("FACTION PROJECTS");
+                UIElements.Header("세력 프로젝트");
 
                 DrawFactionProjects();
             }
@@ -38,7 +38,7 @@ namespace UniverseBounty
         {
             using (UI.HorizontalScope())
             {
-                UI.Label("UNIVERSAL".orange().bold(), UI.MinWidth(350), UI.MaxWidth(350));
+                UI.Label("공용".orange().bold(), UI.MinWidth(350), UI.MaxWidth(350));
                 UI.Space(10);
                 DrawResearchButton(1000, UniversalResearchAction);
                 UI.Space(10);
@@ -100,7 +100,7 @@ namespace UniverseBounty
         private static void DrawResearchButton(float value, Action<float> action)
         {
             var actualValue = value / ResearchSpeedModifier;
-            var text = value > 0 ? $"+ {actualValue:N0}" : "COMPLETE";
+            var text = value > 0 ? $"+ {actualValue:N0}" : "완료";
             UI.ActionButton(text, () => action(actualValue), UIStyles.StandardButtonStyle, UI.MinWidth(150), UI.MaxWidth(150));
         }
 


### PR DESCRIPTION
## Summary
- translate tab labels in `Main.cs`
- localize economy UI strings and resource names
- localize research UI strings
- localize faction UI strings and hints
- localize councilor UI strings and buttons

## Testing
- `dotnet build UniverseBountyMod.sln` *(fails: missing Terra Invicta assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_688585126e208325b514ca07cc095c1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all user-facing interface text from English to Korean across various sections, including tabs, councilor attributes, economy resources, factions, and research UI. All labels, headers, and button texts now appear in Korean for a localized user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->